### PR TITLE
Upgrade to 14.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>Integration of github-corner for Vaadin 14+</description>
 
     <properties>
-        <vaadin.version>14.0.0.beta2</vaadin.version>
+        <vaadin.version>14.0.10</vaadin.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/org/vaadin/artur/github_corner/GitHubCorner.java
+++ b/src/main/java/org/vaadin/artur/github_corner/GitHubCorner.java
@@ -10,8 +10,7 @@ import com.vaadin.flow.component.html.Anchor;
 
 @Tag("github-corner")
 @NpmPackage(value = "github-corner", version = "2.0.3")
-// "@vaadin/../" is a workaround for https://github.com/vaadin/flow/issues/5761
-@JsModule("@vaadin/../github-corner/index.js")
+@JsModule("github-corner/index.js")
 public class GitHubCorner extends Component {
 
     private Anchor anchor;


### PR DESCRIPTION
Since https://github.com/vaadin/flow/issues/5761 is already fixed, the workaround is no longer needed.