### PR TITLE
Change slf4j-simple dependency scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The dependency with `slf4j-simple` is not required by the addon itself (though it is used by the demo, with test scope). In conjunction with Spring Boot it prevents the application from starting, since there are conflicting implementation of Logger.